### PR TITLE
set auto_scale_formula etc to nothing if auto_scale isn't used

### DIFF
--- a/src/core/batch_shortcuts.jl
+++ b/src/core/batch_shortcuts.jl
@@ -65,6 +65,7 @@ function create_pool(; enable_auto_scale=false, auto_scale_formula=nothing,
     auto_scale_evaluation_interval_minutes=nothing, image_resource_id=nothing, 
     container_registry=nothing)
 
+    (~enable_auto_scale) && (auto_scale_formula=auto_scale_evaluation_interval_minutes=nothing)
     # Autoscaling?
     for client in __clients__
         create_blob_containers(client["blob_client"], [__container__])


### PR DESCRIPTION
Now `create_pool(;enable_auto_scale=false, auto_scale_formula=xxx)` renders an error `Failed to start pool 1 of 1 in eastus. Verify that you have correct credentials, a batch account with AAD authentication and that pool parameters are correct.` See https://github.com/slimgroup/JUDI4Cloud.jl/pull/5